### PR TITLE
Enable compatibility with https://github.com/atom/node-keytar

### DIFF
--- a/src/CredentialManagement.Test/CredentialManagement.Test.csproj
+++ b/src/CredentialManagement.Test/CredentialManagement.Test.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CredentialManagement.Test</RootNamespace>
     <AssemblyName>CredentialManagement.Test</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <TargetFrameworkProfile />
@@ -24,6 +24,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +33,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -49,6 +51,7 @@
     <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
     <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
     <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
@@ -65,9 +68,12 @@
     <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
     <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="SoftwareApproach.TestingExtensions">
       <HintPath>..\references\SoftwareApproach.TestingExtensions.dll</HintPath>
     </Reference>

--- a/src/CredentialManagement/CredentialManagement.csproj
+++ b/src/CredentialManagement/CredentialManagement.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CredentialManagement</RootNamespace>
     <AssemblyName>CredentialManagement</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
@@ -25,6 +25,7 @@
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RegisterForComInterop>false</RegisterForComInterop>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -35,6 +36,7 @@
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -52,6 +54,7 @@
     <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
     <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
@@ -68,6 +71,7 @@
     <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisRuleDirectories>;C:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
     <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -82,6 +86,7 @@
     <Compile Include="BaseCredentialsPrompt.cs" />
     <Compile Include="Credential.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="StringFormat.cs" />
     <Compile Include="VistaPrompt.cs" />
     <Compile Include="XPPrompt.cs" />
     <Compile Include="CredentialSet.cs" />

--- a/src/CredentialManagement/StringFormat.cs
+++ b/src/CredentialManagement/StringFormat.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using static CredentialManagement.NativeMethods;
+
+namespace CredentialManagement {
+    public enum StringFormat {
+        Unicode,
+        Ansi,
+    }
+
+    internal abstract class StringFormatProvider {
+        public abstract byte[] GetBytes(string Value);
+        public abstract IntPtr StringToCoTaskMem(string Value);
+        public abstract string PtrToString(IntPtr Value, int Size);
+
+        public static StringFormatProvider GetProvider(StringFormat Format) {
+            var ret = default(StringFormatProvider);
+
+            switch (Format) {
+                case StringFormat.Ansi:
+                    ret = new AnsiStringFormatProvider();
+                    break;
+                case StringFormat.Unicode:
+                    ret = new UnicodeStringFormatProvider();
+                    break;
+                default:
+                    break;
+            }
+
+            return ret;
+        }
+
+    }
+
+    internal class AnsiStringFormatProvider : StringFormatProvider {
+        public override byte[] GetBytes(string Value) {
+            return System.Text.Encoding.ASCII.GetBytes(Value);
+        }
+
+        public override IntPtr StringToCoTaskMem(string Value) {
+            return Marshal.StringToCoTaskMemAnsi(Value);
+        }
+
+        public override string PtrToString(IntPtr Value, int Size) {
+            return Marshal.PtrToStringAnsi(Value, Size);
+        }
+    }
+
+    internal class UnicodeStringFormatProvider : StringFormatProvider {
+        public override byte[] GetBytes(string Value) {
+            return System.Text.Encoding.Unicode.GetBytes(Value);
+        }
+
+        public override IntPtr StringToCoTaskMem(string Value) {
+            return Marshal.StringToCoTaskMemUni(Value);
+        }
+
+        public override string PtrToString(IntPtr Value, int Size) {
+            return Marshal.PtrToStringUni(Value, Size / 2);
+        }
+    }
+
+
+
+}


### PR DESCRIPTION
A notable NPM package, https://github.com/atom/node-keytar, tends to write values in Ansi format instead of unicode.  This causes problems when reading the values using this library.

This commit adds a StringFormat enum to the library that allows you to specify whether it should read/write in Ansi or Unicode (default).